### PR TITLE
fix issue 33

### DIFF
--- a/trading_ig/rest.py
+++ b/trading_ig/rest.py
@@ -754,8 +754,8 @@ class IGService:
             })
         last = prices[0]['lastTradedVolume'] or prices[0]['closePrice']['lastTraded']
         df = json_normalize(prices)
-        df = df.set_index('snapshotTimeUTC')
-        df.index = pd.to_datetime(df.index)
+        df = df.set_index('snapshotTime')
+        df.index = pd.to_datetime(df.index,format="%Y:%m:%d-%H:%M:%S")
         df.index.name = 'DateTime'
 
         df_ask = df[['openPrice.ask', 'highPrice.ask',


### PR DESCRIPTION
Fix issue of mismatched date format.

https://github.com/ig-python/ig-markets-api-python-library/issues/33

Time index is local time (of the account) and not UTC.

Two options to address index timezone issue. One set a config parameter for timezone. Or simply take the system timezone at runtime. Either option can be an enhancement.